### PR TITLE
Fix ConnectionMethods from BleDeviceRetrievalMethod

### DIFF
--- a/transfer-manager/src/main/java/eu/europa/ec/eudi/iso18013/transfer/internal/DeviceRetrievalMethodExt.kt
+++ b/transfer-manager/src/main/java/eu/europa/ec/eudi/iso18013/transfer/internal/DeviceRetrievalMethodExt.kt
@@ -25,16 +25,19 @@ import java.util.UUID
 internal val DeviceRetrievalMethod.connectionMethod: List<ConnectionMethod>
     get() = when (this) {
         is BleRetrievalMethod -> {
-            mutableListOf<ConnectionMethod>().apply {
-                val randomUUID = UUID.randomUUID()
-                add(
-                    ConnectionMethodBle(
-                        peripheralServerMode,
-                        centralClientMode,
-                        if (peripheralServerMode) randomUUID else null,
-                        if (centralClientMode) randomUUID else null
+            if (!peripheralServerMode && !centralClientMode) emptyList()
+            else {
+                mutableListOf<ConnectionMethod>().apply {
+                    val randomUUID = UUID.randomUUID()
+                    add(
+                        ConnectionMethodBle(
+                            peripheralServerMode,
+                            centralClientMode,
+                            if (peripheralServerMode) randomUUID else null,
+                            if (centralClientMode) randomUUID else null
+                        )
                     )
-                )
+                }
             }
         }
 

--- a/transfer-manager/src/test/java/eu/europa/ec/eudi/iso18013/transfer/internal/DeviceRetrievalMethodExtTest.kt
+++ b/transfer-manager/src/test/java/eu/europa/ec/eudi/iso18013/transfer/internal/DeviceRetrievalMethodExtTest.kt
@@ -1,5 +1,6 @@
 package eu.europa.ec.eudi.iso18013.transfer.internal
 
+import com.android.identity.util.CborUtil
 import eu.europa.ec.eudi.iso18013.transfer.retrieval.BleRetrievalMethod
 import org.junit.Assert
 import org.junit.Test
@@ -12,6 +13,7 @@ class DeviceRetrievalMethodExtTest(
     private val peripheralServerMode: Boolean,
     private val centralClientMode: Boolean,
     private val clearBleCache: Boolean,
+    private val expectedMethodCount: Int,
 ) {
 
     companion object {
@@ -19,14 +21,14 @@ class DeviceRetrievalMethodExtTest(
         @JvmStatic
         fun data(): List<Array<Any>> {
             return listOf(
-                arrayOf(false, true, false),
-                arrayOf(false, false, false),
-                arrayOf(true, false, false),
-                arrayOf(true, true, false),
-                arrayOf(false, true, true),
-                arrayOf(false, false, true),
-                arrayOf(true, false, true),
-                arrayOf(true, true, true),
+                arrayOf(false, true, false, 1),
+                arrayOf(false, false, false, 0),
+                arrayOf(true, false, false, 1),
+                arrayOf(true, true, false, 1),
+                arrayOf(false, true, true, 1),
+                arrayOf(false, false, true, 0),
+                arrayOf(true, false, true, 1),
+                arrayOf(true, true, true, 1),
             )
         }
     }
@@ -35,10 +37,15 @@ class DeviceRetrievalMethodExtTest(
     fun testDeviceRetrievalMethodConnectionMethodsAndTransportOptions() {
         val bleRetrievalMethod =
             BleRetrievalMethod(peripheralServerMode, centralClientMode, clearBleCache)
-        val connectionMethod = bleRetrievalMethod.connectionMethod
-        Assert.assertEquals(1, connectionMethod.size)
+        val connectionMethods = bleRetrievalMethod.connectionMethod
+        Assert.assertEquals(expectedMethodCount, connectionMethods.size)
+
         val transportOptions = listOf(bleRetrievalMethod).transportOptions
         Assert.assertEquals(clearBleCache, transportOptions.bleClearCache)
+
+        val connectionMethod = connectionMethods.firstOrNull()
+        CborUtil.toDiagnostics(connectionMethod?.toDeviceEngagement() ?: byteArrayOf())
+            .also { println("DeviceEngagement: $it") }
     }
 
 }


### PR DESCRIPTION
Get on ConnectionMethod for BLE even if both Peripheral and Client modes are enabled