### PR TITLE
Document single request-response cycle limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,7 +383,11 @@ requested document's keys, that are needed to sign the response. In this case, e
 `DisclosedDocument` must contain the `keyUnlockData` property that defines the key unlocking.
 
 Finally, the response is sent back to the verifier with the
-`TransferManager.sendResponse(Response)`
+`TransferManager.sendResponse(Response)`.
+
+> **Note:** Currently, only a single request-response cycle per session is supported.
+> Sending a response automatically terminates the presentation session. To perform another
+> exchange, a new session must be started.
 
 The following example demonstrates how to handle the request and send the response.
 

--- a/transfer-manager/src/main/java/eu/europa/ec/eudi/iso18013/transfer/TransferManager.kt
+++ b/transfer-manager/src/main/java/eu/europa/ec/eudi/iso18013/transfer/TransferManager.kt
@@ -61,7 +61,12 @@ interface TransferManager : TransferEvent.Listenable {
     fun startEngagementToApp(intent: Intent)
 
     /**
-     * Sends response bytes to the connected reader
+     * Sends response bytes to the connected reader and terminates the session.
+     *
+     * **Note:** Currently, only a single request-response cycle per session is supported.
+     * Calling this method sends the response along with a session termination signal,
+     * ending the presentation session. To perform another exchange, a new session must be started.
+     *
      * To generate the response, use the [RequestProcessor.ProcessedRequest.Success.generateResponse]
      * method.
      * @param response The response to be sent

--- a/transfer-manager/src/main/java/eu/europa/ec/eudi/iso18013/transfer/TransferManagerImpl.kt
+++ b/transfer-manager/src/main/java/eu/europa/ec/eudi/iso18013/transfer/TransferManagerImpl.kt
@@ -317,7 +317,14 @@ class TransferManagerImpl @JvmOverloads constructor(
     }
 
     /**
-     * Sends the response bytes to the connected mdoc verifier
+     * Sends the response bytes to the connected mdoc verifier and terminates the session.
+     *
+     * **Note:** Currently, only a single request-response cycle per session is supported.
+     * The response is sent with [Constants.SESSION_DATA_STATUS_SESSION_TERMINATION], which
+     * signals the end of the session to the verifier. Although ISO 18013-5 permits multiple
+     * request-response exchanges within a single session, this library always terminates
+     * the session after the first response.
+     *
      * To generate the response, use the [eu.europa.ec.eudi.iso18013.transfer.response.device.ProcessedDeviceRequest.generateResponse]
      * that is provided by the [eu.europa.ec.eudi.iso18013.transfer.TransferEvent.RequestReceived] event.
      * @param response the response to send


### PR DESCRIPTION
## Summary
- Document in KDoc and README that the library currently supports only one request-response cycle per session
- After sending a response, the session is always terminated with `SESSION_DATA_STATUS_SESSION_TERMINATION`

Closes #110