### PR TITLE
Fix Period reader-auth profile validator to check current time

### DIFF
--- a/transfer-manager/src/main/java/eu/europa/ec/eudi/iso18013/transfer/readerauth/profile/Period.kt
+++ b/transfer-manager/src/main/java/eu/europa/ec/eudi/iso18013/transfer/readerauth/profile/Period.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025 European Commission
+ * Copyright (c) 2023-2026 European Commission
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package eu.europa.ec.eudi.iso18013.transfer.readerauth.profile
 import android.util.Log
 import eu.europa.ec.eudi.iso18013.transfer.internal.TAG
 import java.security.cert.X509Certificate
+import java.util.Date
 import java.util.concurrent.TimeUnit
 
 class Period : ProfileValidation {
@@ -36,13 +37,16 @@ class Period : ProfileValidation {
         val fromDate = readerAuthCertificate.notBefore
         val diff = expireDate.time - fromDate.time
 
-        return (
-                TimeUnit.DAYS.convert(
-                    diff,
-                    TimeUnit.MILLISECONDS,
-                ) <= MAX_VALIDITY_PERIOD_DAYS
-                ).also {
-                Log.d(this.TAG, "ValidityPeriod: $it")
-            }
+        val durationWithinLimit = TimeUnit.DAYS.convert(
+            diff,
+            TimeUnit.MILLISECONDS,
+        ) <= MAX_VALIDITY_PERIOD_DAYS
+
+        val now = Date()
+        val currentlyWithinValidity = !now.before(fromDate) && !now.after(expireDate)
+
+        return (durationWithinLimit && currentlyWithinValidity).also {
+            Log.d(this.TAG, "ValidityPeriod: $it")
+        }
     }
 }

--- a/transfer-manager/src/test/java/eu/europa/ec/eudi/iso18013/transfer/readerauth/CertificateProvider.kt
+++ b/transfer-manager/src/test/java/eu/europa/ec/eudi/iso18013/transfer/readerauth/CertificateProvider.kt
@@ -333,6 +333,50 @@ val revokedCertificateCRL: java.security.cert.X509CRL by lazy {
     JcaX509CRLConverter().getCRL(crlBuilder.build(signer))
 }
 
+private fun buildLeafCertificateWithValidity(
+    notBefore: Date,
+    notAfter: Date,
+): X509Certificate {
+    val keyPair = KeyPairGenerator.getInstance("EC").apply {
+        initialize(ECGenParameterSpec("secp256r1"))
+    }.generateKeyPair()
+    val serialNumber = BigInteger(64, SecureRandom())
+    val issuer = X500Name(trustedCertificate.subjectX500Principal.name)
+    val subject = X500Name("CN=ValidityTestCertificate")
+    val builder = JcaX509v3CertificateBuilder(
+        issuer,
+        serialNumber,
+        notBefore,
+        notAfter,
+        subject,
+        keyPair.public,
+    )
+    val signer = JcaContentSignerBuilder(signatureAlgorithm).build(trustedKeyPair.private)
+    return JcaX509CertificateConverter().getCertificate(builder.build(signer))
+}
+
+val notYetValidCertificate: X509Certificate by lazy {
+    // notBefore starts 1 day in the future
+    val notBefore = Date.from(Instant.now().plusSeconds(86400))
+    val notAfter = Date(notBefore.time + 30 * 86400000L)
+    buildLeafCertificateWithValidity(notBefore, notAfter)
+}
+
+val expiredCertificate: X509Certificate by lazy {
+    // notAfter ended 1 day ago
+    val notAfter = Date.from(Instant.now().minusSeconds(86400))
+    val notBefore = Date(notAfter.time - 30 * 86400000L)
+    buildLeafCertificateWithValidity(notBefore, notAfter)
+}
+
+val tooLongButCurrentlyValidCertificate: X509Certificate by lazy {
+    // Currently valid window, but total duration exceeds MAX_VALIDITY_PERIOD_DAYS (1187)
+    val notBefore = Date.from(Instant.now().minusSeconds(86400))
+    // 1500 days after notBefore
+    val notAfter = Date(notBefore.time + 1500L * 86400000L)
+    buildLeafCertificateWithValidity(notBefore, notAfter)
+}
+
 val invalidCertificate: X509Certificate by lazy {
     val keyPair = KeyPairGenerator.getInstance("RSA").apply {
         initialize(2048)
@@ -365,3 +409,9 @@ fun loadValidThreeCertChain(): List<X509Certificate> = validThreeCertChain
 
 fun loadThreeCertChainWithIntermediateAkiMismatch(): List<X509Certificate> =
     threeCertChainWithIntermediateAkiMismatch
+
+fun loadNotYetValidCert(): X509Certificate = notYetValidCertificate
+
+fun loadExpiredCert(): X509Certificate = expiredCertificate
+
+fun loadTooLongButCurrentlyValidCert(): X509Certificate = tooLongButCurrentlyValidCertificate

--- a/transfer-manager/src/test/java/eu/europa/ec/eudi/iso18013/transfer/readerauth/profile/PeriodTest.kt
+++ b/transfer-manager/src/test/java/eu/europa/ec/eudi/iso18013/transfer/readerauth/profile/PeriodTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025 European Commission
+ * Copyright (c) 2023-2026 European Commission
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,10 @@ package eu.europa.ec.eudi.iso18013.transfer.readerauth.profile
 import android.util.Log
 import eu.europa.ec.eudi.iso18013.transfer.mockAndroidLog
 import eu.europa.ec.eudi.iso18013.transfer.readerauth.loadCert
+import eu.europa.ec.eudi.iso18013.transfer.readerauth.loadExpiredCert
 import eu.europa.ec.eudi.iso18013.transfer.readerauth.loadInvalidCert
+import eu.europa.ec.eudi.iso18013.transfer.readerauth.loadNotYetValidCert
+import eu.europa.ec.eudi.iso18013.transfer.readerauth.loadTooLongButCurrentlyValidCert
 import eu.europa.ec.eudi.iso18013.transfer.readerauth.loadTrustCert
 import org.junit.After
 import org.junit.Before
@@ -63,6 +66,36 @@ class PeriodTest {
         val result = validation.validate(invalidCert, trustCA)
 
         // Assert the result
+        assertFalse(result)
+    }
+
+    @Test
+    fun testVerify_NotYetValid() {
+        // Certificate whose notBefore is in the future; current time is outside [notBefore, notAfter].
+        val notYetValid = listOf(loadNotYetValidCert())
+
+        val result = validation.validate(notYetValid, trustCA)
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun testVerify_Expired() {
+        // Certificate whose notAfter is in the past; current time is outside [notBefore, notAfter].
+        val expired = listOf(loadExpiredCert())
+
+        val result = validation.validate(expired, trustCA)
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun testVerify_TooLongButCurrentlyValid() {
+        // Certificate currently in its validity window, but total lifetime exceeds MAX_VALIDITY_PERIOD_DAYS.
+        val tooLong = listOf(loadTooLongButCurrentlyValidCert())
+
+        val result = validation.validate(tooLong, trustCA)
+
         assertFalse(result)
     }
 


### PR DESCRIPTION
## Summary

- Adds a current-time `[notBefore, notAfter]` check to `Period.validate()` in the reader-auth profile validator, in addition to the existing 1,187-day maximum-duration check. Both must pass.
- Defense-in-depth: the PKIX path validator already enforces the current-time check at the system level, but the `Period` profile validator is intended as a self-contained ISO 18013-5 Annex B (Table B.6) conformance check and should reflect the full Table B.6 validity semantics if reused outside the PKIX path.
- Extends `PeriodTest` with `testVerify_NotYetValid`, `testVerify_Expired`, and `testVerify_TooLongButCurrentlyValid`, plus corresponding cert generators in `CertificateProvider`.

Fixes #113

## Test plan

- [x] New tests fail against unfixed code (`NotYetValid`, `Expired`), demonstrating the bug
- [x] All `PeriodTest` cases pass after the fix (5 tests, 0 failures)
- [x] Full `:transfer-manager:testDebugUnitTest` suite passes